### PR TITLE
feat: support for specifying AWS region

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 **********
 
+Added
+=====
+
+* feat: support for specifying AWS region
+
 3.4.1
 *****
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,23 @@
+Change Log
+##########
+
+..
+   All enhancements and patches to openedx-django-pyfs will be documented
+   in this file.  It adheres to the structure of https://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+
+   This project adheres to Semantic Versioning (https://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+
+Unreleased
+**********
+
+3.4.1
+*****
+
+Fixed
+=====
+
+* fix: pass AWS credentials correctly (#168)

--- a/djpyfs/__init__.py
+++ b/djpyfs/__init__.py
@@ -1,3 +1,3 @@
 # pylint: disable=django-not-configured
 """init file"""
-__version__ = '3.4.0'
+__version__ = '3.4.1'

--- a/djpyfs/djpyfs.py
+++ b/djpyfs/djpyfs.py
@@ -126,13 +126,16 @@ def get_s3fs(namespace):
     """
     key_id = DJFS_SETTINGS.get('aws_access_key_id', None)
     key_secret = DJFS_SETTINGS.get('aws_secret_access_key', None)
+    region = DJFS_SETTINGS.get('region', None)
 
     fullpath = namespace
 
     if 'prefix' in DJFS_SETTINGS:
         fullpath = os.path.join(DJFS_SETTINGS['prefix'], fullpath)
 
-    s3fs = S3FS(DJFS_SETTINGS['bucket'], fullpath, aws_access_key_id=key_id, aws_secret_access_key=key_secret)
+    s3fs = S3FS(DJFS_SETTINGS['bucket'], fullpath,
+                aws_access_key_id=key_id, aws_secret_access_key=key_secret,
+                region=region)
 
     def get_s3_url(self, filename, timeout=60):  # pylint: disable=unused-argument
         """
@@ -154,7 +157,9 @@ def get_s3fs(namespace):
 
         try:
             if not S3CONN:
-                S3CONN = boto3.client('s3', aws_access_key_id=key_id, aws_secret_access_key=key_secret)
+                S3CONN = boto3.client('s3', aws_access_key_id=key_id,
+                                      aws_secret_access_key=key_secret,
+                                      region_name=region)
 
             return S3CONN.generate_presigned_url(
                 "get_object",
@@ -168,7 +173,9 @@ def get_s3fs(namespace):
         except Exception:  # pylint: disable=broad-except
             # Retry on error; typically, if the connection has timed out, but
             # the broad except covers all errors.
-            S3CONN = boto3.client('s3', aws_access_key_id=key_id, aws_secret_access_key=key_secret)
+            S3CONN = boto3.client('s3', aws_access_key_id=key_id,
+                                  aws_secret_access_key=key_secret,
+                                  region_name=region)
 
             return S3CONN.generate_presigned_url(
                 "get_object",

--- a/djpyfs/djpyfs.py
+++ b/djpyfs/djpyfs.py
@@ -132,7 +132,7 @@ def get_s3fs(namespace):
     if 'prefix' in DJFS_SETTINGS:
         fullpath = os.path.join(DJFS_SETTINGS['prefix'], fullpath)
 
-    s3fs = S3FS(DJFS_SETTINGS['bucket'], fullpath, aws_secret_access_key=key_id, aws_access_key_id=key_secret)
+    s3fs = S3FS(DJFS_SETTINGS['bucket'], fullpath, aws_access_key_id=key_id, aws_secret_access_key=key_secret)
 
     def get_s3_url(self, filename, timeout=60):  # pylint: disable=unused-argument
         """

--- a/djpyfs/tests.py
+++ b/djpyfs/tests.py
@@ -320,6 +320,11 @@ class S3Test(_BaseFs):
         self.conn = boto3.resource('s3')
         self.conn.create_bucket(Bucket=djpyfs.DJFS_SETTINGS['bucket'])
 
+    def test_aws_credentials(self):
+        fs = djpyfs.get_filesystem(self.namespace)
+        self.assertEqual(fs.aws_access_key_id, 'foo')
+        self.assertEqual(fs.aws_secret_access_key, 'bar')
+
     # This test is only relevant for S3. Generate some fake errors to make
     # sure we cover the retry code.
     def test_get_url_retry(self):


### PR DESCRIPTION
## Description

Support for specifying AWS region.

## Supporting information

Do not merge this. It is meant for review but is based on the branch of openedx/django-pyfs#168. I will open another upstream PR once that one is merged.

## Testing instructions

1. Set 'region' in settings.DJFS.
2. Test that uploads to a bucket not in the default region work.
3. Test that generated URLs contain the region name.

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-8077