### PR TITLE
chore: require tox<4

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,4 +2,4 @@
 
 -c constraints.txt
 
-tox                       # Virtualenv management for tests
+tox<4                     # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,12 +4,6 @@
 #
 #    pip-compile --output-file=requirements/ci.txt requirements/ci.in
 #
-cachetools==5.3.2
-    # via tox
-chardet==5.2.0
-    # via tox
-colorama==0.4.6
-    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -17,22 +11,18 @@ filelock==3.13.1
     #   tox
     #   virtualenv
 packaging==23.2
-    # via
-    #   pyproject-api
-    #   tox
+    # via tox
 platformdirs==4.1.0
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 pluggy==1.3.0
     # via tox
-pyproject-api==1.6.1
+py==1.11.0
+    # via tox
+six==1.16.0
     # via tox
 tomli==2.0.1
-    # via
-    #   pyproject-api
-    #   tox
-tox==4.11.4
+    # via tox
+tox==3.28.0
     # via -r requirements/ci.in
 virtualenv==20.25.0
     # via tox

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,4 +3,4 @@
 -c constraints.txt
 
 pip-tools                 # Requirements file management
-tox                       # virtualenv management for tests
+tox<4                     # virtualenv management for tests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,14 +16,8 @@ botocore==1.33.11
     #   s3transfer
 build==1.0.3
     # via pip-tools
-cachetools==5.3.2
-    # via tox
-chardet==5.2.0
-    # via tox
 click==8.1.7
     # via pip-tools
-colorama==0.4.6
-    # via tox
 distlib==0.3.7
     # via virtualenv
 django==3.2.23
@@ -49,17 +43,14 @@ jmespath==1.0.1
 packaging==23.2
     # via
     #   build
-    #   pyproject-api
     #   tox
 pip-tools==7.3.0
     # via -r requirements/dev.in
 platformdirs==4.1.0
-    # via
-    #   tox
-    #   virtualenv
+    # via virtualenv
 pluggy==1.3.0
     # via tox
-pyproject-api==1.6.1
+py==1.11.0
     # via tox
 pyproject-hooks==1.0.0
     # via build
@@ -74,16 +65,16 @@ six==1.16.0
     #   fs
     #   fs-s3fs
     #   python-dateutil
+    #   tox
 sqlparse==0.4.4
     # via django
 tomli==2.0.1
     # via
     #   build
     #   pip-tools
-    #   pyproject-api
     #   pyproject-hooks
     #   tox
-tox==4.11.4
+tox==3.28.0
     # via -r requirements/dev.in
 typing-extensions==4.9.0
     # via asgiref


### PR DESCRIPTION
## Description

Require tox<4 for compatibility with xblock 1.6.2.

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-8077